### PR TITLE
Add prometheus metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+type metric struct {
+	Name string
+	Help string
+}
+
+var (
+	Namespace = "authenticator"
+	Subsystem = "hostapd"
+
+	AuthSuccess = metric{
+		Name: "auth_success_total",
+		Help: "total successful authentications for wpa supplicants",
+	}
+
+	AuthFailed = metric{
+		Name: "auth_failure_total",
+		Help: "total failed authentications for wpa supplicants",
+	}
+)

--- a/pkg/configgen/configgen.go
+++ b/pkg/configgen/configgen.go
@@ -223,6 +223,9 @@ func (g *ConfigGenerator) Daemonset() *appsv1.DaemonSet {
 							}, {
 								Name:  "UNPROTECTED_UDP_PORTS",
 								Value: unprotectedUdpList,
+							}, {
+								Name:      "AUTHENTICATOR_HOST",
+								ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"}},
 							}}),
 					},
 					Volumes: []corev1.Volume{{

--- a/pkg/hostap/monitor.go
+++ b/pkg/hostap/monitor.go
@@ -177,14 +177,18 @@ func (m *InterfaceMonitor) handleHostapdEvent(eventStr string) error {
 	}()
 	eventKeyStr := eventStrSlice[0][strings.Index(eventStrSlice[0], ">")+1:]
 	switch eventKeyStr {
-	case staConnectedEvent, eapSuccessEvent:
-		m.logEvent(kapi.EventTypeNormal, "authenticated supplicant %s", eventStrSlice[1])
+	case staConnectedEvent:
 		return m.handleAuthenticateEvent(eventStrSlice[1])
+	case eapSuccessEvent:
+		m.logEvent(kapi.EventTypeNormal, "authenticated supplicant %s", eventStrSlice[1])
+		stats.Authenticated(m.IfName)
 	case staDisconnectedEvent:
 		m.logEvent(kapi.EventTypeNormal, "deauthenticated supplicant %s", eventStrSlice[1])
+		stats.DeAuthenticated(m.IfName)
 		return m.handleDeAuthenticateEvent(eventStrSlice[1])
 	case eapFailureEvent:
 		m.logEvent(kapi.EventTypeWarning, "authentication failure for supplicant %s", eventStrSlice[1])
+		stats.AuthFailed(m.IfName)
 	default:
 		level.Info(m.Logger).Log("hostapd-event", "unhandled event", m.IfName, eventStr)
 	}

--- a/pkg/hostap/stats.go
+++ b/pkg/hostap/stats.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hostap
+
+import (
+	authmetrics "github.com/openshift-kni/eapol-operator/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var labels = []string{"interface"}
+
+var stats = metrics{
+	authSuccess: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: authmetrics.Namespace,
+		Subsystem: authmetrics.Subsystem,
+		Name:      authmetrics.AuthSuccess.Name,
+		Help:      authmetrics.AuthSuccess.Help,
+	}, labels),
+
+	authFailed: prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: authmetrics.Namespace,
+		Subsystem: authmetrics.Subsystem,
+		Name:      authmetrics.AuthFailed.Name,
+		Help:      authmetrics.AuthFailed.Help,
+	}, labels),
+}
+
+type metrics struct {
+	authSuccess *prometheus.GaugeVec
+	authFailed  *prometheus.CounterVec
+}
+
+func init() {
+	prometheus.MustRegister(stats.authSuccess)
+	prometheus.MustRegister(stats.authFailed)
+}
+
+func (m *metrics) Authenticated(iface string) {
+	m.authSuccess.WithLabelValues(iface).Inc()
+}
+
+func (m *metrics) DeAuthenticated(iface string) {
+	m.authSuccess.WithLabelValues(iface).Dec()
+}
+
+func (m *metrics) AuthFailed(iface string) {
+	m.authFailed.WithLabelValues(iface).Inc()
+}


### PR DESCRIPTION
This commits adds required code to start http endpoint for prometheus metrics and registers hostapd metrics for auth success and failure.