### PR TITLE
Implement traffic control for IPv6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/go-test/deep v1.0.8
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
+	github.com/prometheus/client_golang v1.11.0
 	github.com/vishvananda/netlink v1.1.0
 	k8s.io/api v0.23.0
 	k8s.io/apimachinery v0.23.0
@@ -46,7 +47,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.28.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect


### PR DESCRIPTION
This provides a facility to allow ipv6 traffic on specified ports irrespective of client being authenticated or not. The specified port is applied for both tcp and udp protocols.