### PR TITLE
Deployment fixes for sriov cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= quay.io/openshift-kni/controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,5 +14,5 @@ configMapGenerator:
 
 images:
 - name: controller
-  newName: controller
+  newName: quay.io/openshift-kni/controller
   newTag: latest

--- a/controllers/authenticator_controller.go
+++ b/controllers/authenticator_controller.go
@@ -159,6 +159,7 @@ func (r *AuthenticatorReconciler) syncRbacResources(ctx context.Context, owner *
 	_, err := r.getServiceAccount(ctx, namespace)
 	if errors.IsNotFound(err) {
 		r.rbacResources.serviceAccount.Namespace = namespace
+		r.rbacResources.serviceAccount.ResourceVersion = ""
 		err = r.createOwned(ctx, owner, r.rbacResources.serviceAccount)
 		if err != nil {
 			return fmt.Errorf("error creating authenticator service account: %v, err: %v",
@@ -170,6 +171,7 @@ func (r *AuthenticatorReconciler) syncRbacResources(ctx context.Context, owner *
 	_, err = r.getRole(ctx, namespace)
 	if errors.IsNotFound(err) {
 		r.rbacResources.role.Namespace = namespace
+		r.rbacResources.role.ResourceVersion = ""
 		err = r.createOwned(ctx, owner, r.rbacResources.role)
 		if err != nil {
 			return fmt.Errorf("error creating authenticator role: %v, err: %v",
@@ -181,6 +183,7 @@ func (r *AuthenticatorReconciler) syncRbacResources(ctx context.Context, owner *
 	_, err = r.getRoleBinding(ctx, namespace)
 	if errors.IsNotFound(err) {
 		r.rbacResources.roleBinding.Namespace = namespace
+		r.rbacResources.roleBinding.ResourceVersion = ""
 		r.rbacResources.roleBinding.Subjects[0].Namespace = namespace
 		err = r.createOwned(ctx, owner, r.rbacResources.roleBinding)
 		if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -76,7 +76,8 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme: scheme.Scheme,
+		Scheme:             scheme.Scheme,
+		MetricsBindAddress: ":7472",
 	})
 	Expect(err).ToNot(HaveOccurred())
 	AuthenticatorRbacPath = "../bindata/deployment/authenticator-rbac"


### PR DESCRIPTION
This provides various fixes that are required to test eapol operator on a OCP cluster with SRIOV interface.