### PR TITLE
Add iproute-tc pkg for build root dockerfile

### DIFF
--- a/images/build-root/Dockerfile
+++ b/images/build-root/Dockerfile
@@ -1,2 +1,2 @@
 FROM registry.ci.openshift.org/openshift/release:rhel-9-release-golang-1.20-openshift-4.14
-RUN dnf install -y shellcheck
+RUN dnf install -y ShellCheck iproute-tc


### PR DESCRIPTION
This installs iproute-tc package on the buildroot docker container so that unit tests would pass seemlessly when it runs tc commands.