### PR TITLE
CNFCERT-1258: Add kustomize validation check

### DIFF
--- a/.github/workflows/kustomize-validation.yml
+++ b/.github/workflows/kustomize-validation.yml
@@ -1,0 +1,47 @@
+name: Kustomize Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  kustomize-validation:
+    name: Validate Kustomization Files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Kustomize
+        run: |
+          # Download with retries to prevent flaky CI failures
+          MAX_ATTEMPTS=3
+          ATTEMPT=1
+          
+          while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+            echo "Attempt $ATTEMPT of $MAX_ATTEMPTS: Downloading kustomize install script..."
+            if curl -fsSL --retry 3 --retry-delay 2 "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash; then
+              echo "Successfully downloaded and installed kustomize"
+              break
+            else
+              echo "Failed to install kustomize"
+              if [ $ATTEMPT -eq $MAX_ATTEMPTS ]; then
+                echo "All attempts failed"
+                exit 1
+              fi
+              echo "Waiting 5 seconds before retry..."
+              sleep 5
+              ATTEMPT=$((ATTEMPT + 1))
+            fi
+          done
+          
+          sudo mv kustomize /usr/local/bin/
+          kustomize version
+
+      - name: Validate Kustomization Files
+        run: make test-kustomize
+

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ shellcheck: ## Run shellcheck on critical shell scripts
 test: manifests generate fmt vet envtest shellcheck ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: test-kustomize
+test-kustomize: ## Validate all kustomization.yaml files can build successfully.
+	@hack/test-kustomize.sh
+
 ##@ Build
 
 .PHONY: build

--- a/hack/test-kustomize.sh
+++ b/hack/test-kustomize.sh
@@ -57,14 +57,14 @@ fi
 for kustomize_file in "${kustomize_files[@]}"; do
     dir=$(dirname "$kustomize_file")
     echo -n "  $dir: "
-    
+
     # Check if this directory requires external plugins
     if is_excluded "$dir"; then
         echo -e "${BLUE}SKIPPED${NC} (requires external plugins)"
         SKIPPED=$((SKIPPED + 1))
         continue
     fi
-    
+
     # Try to build the kustomization
     if kustomize build "$dir" > /dev/null 2>&1; then
         echo -e "${GREEN}OK${NC}"

--- a/hack/test-kustomize.sh
+++ b/hack/test-kustomize.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Directories that require external kustomize plugins
+# Currently none in this repository - all kustomizations use standard kustomize features
+EXCLUDED_DIRS=()
+
+# Check if kustomize is installed
+if ! command -v kustomize &> /dev/null; then
+    echo -e "${RED}ERROR: kustomize is not installed${NC}"
+    echo ""
+    echo "Please install kustomize to run this check:"
+    echo "  - macOS: brew install kustomize"
+    echo "  - Linux: curl -s \"https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh\" | bash"
+    echo "  - Manual: https://kubectl.docs.kubernetes.io/installation/kustomize/"
+    echo ""
+    exit 1
+fi
+
+echo "Checking all kustomization.yaml files can build successfully..."
+echo ""
+
+ERRORS=0
+CHECKED=0
+SKIPPED=0
+
+# Helper function to check if directory should be excluded
+is_excluded() {
+    local dir="$1"
+    for excluded in "${EXCLUDED_DIRS[@]}"; do
+        if [ "$dir" = "$excluded" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Find all kustomization.yaml files
+kustomize_files=()
+while IFS= read -r file; do
+    kustomize_files+=("$file")
+done < <(find . -name 'kustomization.yaml' -not -path '*/venv/*' -not -path '*/.git/*' -not -path '*/vendor/*' | sort)
+
+if [ ${#kustomize_files[@]} -eq 0 ]; then
+    echo -e "${YELLOW}WARNING: No kustomization.yaml files found${NC}"
+    exit 0
+fi
+
+for kustomize_file in "${kustomize_files[@]}"; do
+    dir=$(dirname "$kustomize_file")
+    echo -n "  $dir: "
+    
+    # Check if this directory requires external plugins
+    if is_excluded "$dir"; then
+        echo -e "${BLUE}SKIPPED${NC} (requires external plugins)"
+        SKIPPED=$((SKIPPED + 1))
+        continue
+    fi
+    
+    # Try to build the kustomization
+    if kustomize build "$dir" > /dev/null 2>&1; then
+        echo -e "${GREEN}OK${NC}"
+        CHECKED=$((CHECKED + 1))
+    else
+        echo -e "${RED}FAILED${NC}"
+        echo -e "${YELLOW}    Error details:${NC}"
+        kustomize build "$dir" 2>&1 | sed 's/^/    /'
+        echo ""
+        ERRORS=$((ERRORS + 1))
+        CHECKED=$((CHECKED + 1))
+    fi
+done
+
+echo ""
+if [ $SKIPPED -gt 0 ]; then
+    echo "Summary: Checked $CHECKED kustomization.yaml files, skipped $SKIPPED (require external plugins)"
+else
+    echo "Summary: Checked $CHECKED kustomization.yaml files"
+fi
+
+if [[ $ERRORS -eq 0 ]]; then
+    echo -e "${GREEN}All kustomization files validated successfully!${NC}"
+    exit 0
+else
+    echo -e "${RED}$ERRORS kustomization file(s) failed validation${NC}"
+    exit 1
+fi
+


### PR DESCRIPTION
Similar to: https://github.com/openshift-kni/telco-reference/pull/433

Changes:
- Adds a quick PR check that attempts to `kustomize build` appropriate files.  Only runs against `main`.
- Adds a make path for `make test-kustomize` which runs the script.  Users can run this locally as well as there are safeguards to ensure `kustomize` exists first.
- Skips YAMLs that might require external plugins.  See `EXCLUDED_DIRS`.

Example run:

```
$ make test-kustomize 
Checking all kustomization.yaml files can build successfully...

  ./config/crd: OK
  ./config/default: OK
  ./config/manager: OK
  ./config/manifests: OK
  ./config/prometheus: OK
  ./config/rbac: OK
  ./config/samples: OK
  ./config/scorecard: OK

Summary: Checked 8 kustomization.yaml files
All kustomization files validated successfully!
```